### PR TITLE
Cli Additions

### DIFF
--- a/cli/minipresto/commands/cmd_down.py
+++ b/cli/minipresto/commands/cmd_down.py
@@ -15,10 +15,13 @@ Brings down all running minipresto containers. This command follows the
 behavior of `docker-compose down`, where containers are both stopped and
 removed.
 """)
+@click.option("-k", "--keep", is_flag=True, default=False, help="""
+Does not remove any containers; instead, they will only be stopped.
+""")
 
 
 @pass_environment
-def cli(ctx):
+def cli(ctx, keep):
     """
     Down command for minipresto. Exits with a 0 status code if there are no
     running minipresto containers.
@@ -36,7 +39,9 @@ def cli(ctx):
 
     for container in containers:
         container.stop()
-        container.remove()  # Default behavior of Compose is to remove containers
-        ctx.vlog(f"Stopped/removed container: {container.short_id} | {container.name}")
+        ctx.vlog(f"Stopped container: {container.short_id} | {container.name}")
+        if not keep:
+            container.remove()  # Default behavior of Compose is to remove containers
+            ctx.vlog(f"Removed container: {container.short_id} | {container.name}")
 
     ctx.log(f"Brought down all running minipresto containers")

--- a/cli/minipresto/commands/cmd_down.py
+++ b/cli/minipresto/commands/cmd_down.py
@@ -40,7 +40,8 @@ def cli(ctx, keep):
     for container in containers:
         container.stop()
         ctx.vlog(f"Stopped container: {container.short_id} | {container.name}")
-        if not keep:
+    if not keep:
+        for container in containers:
             container.remove()  # Default behavior of Compose is to remove containers
             ctx.vlog(f"Removed container: {container.short_id} | {container.name}")
 

--- a/cli/minipresto/commands/cmd_provision.py
+++ b/cli/minipresto/commands/cmd_provision.py
@@ -245,7 +245,8 @@ def handle_config_properties(ctx):
     ctx.vlog("Checking config.properties for duplicate properties")
     executor = CommandExecutor(ctx)
     output = executor.execute_commands(
-        commands=["docker exec -i presto cat /usr/lib/presto/etc/config.properties"]
+        commands=["docker exec -i presto cat /usr/lib/presto/etc/config.properties"],
+        suppress_output=True
     )
 
     config_props = output[0].get("output", False)

--- a/cli/minipresto/commands/cmd_remove.py
+++ b/cli/minipresto/commands/cmd_remove.py
@@ -39,7 +39,7 @@ def cli(ctx, images, volumes, label, force):
     """Remove command for minipresto."""
 
     docker_client = check_daemon()
-    label = convert_MultiArgOption_to_list(label)
+    label, = convert_MultiArgOption_to_list(label)
 
     if images:
         remove_items(docker_client, {"item_type": IMAGE}, force, label)

--- a/cli/minipresto/commands/core.py
+++ b/cli/minipresto/commands/core.py
@@ -64,7 +64,7 @@ class MultiArgOption(click.Option):
 
 
 class CommandExecutor(object):
-    def __init__(self, ctx):
+    def __init__(self, ctx=None):
         """
         Executes commands in the host shell with customized handling of
         stdout/stderr output.
@@ -83,9 +83,14 @@ class CommandExecutor(object):
         - `environment: {}`: A dictionary of environment variables to pass to
           the subprocess
         - `commands: []`: A list of commands that will be executed in the order
-          provides
+          provided
         - `suppress_output: False`: If `True`, output from the executed command
-          will be directed to DEVNULL.
+          will be suppressed.
+        - `container: None`: A Docker container object. If passed in, the
+          command will be executed through the Docker SDK instead of the
+          subprocess module.
+        - `docker_user: root`: The user to execute the command as in the Docker
+          container.
 
         Return Values
         -------------
@@ -95,50 +100,105 @@ class CommandExecutor(object):
             - `return_code`: the return code of the command
         """
 
-        environment = kwargs.get("environment", {})
-        environment = self.construct_environment(environment)
+        kwargs["environment"] = self.construct_environment(
+            kwargs.get("environment", {})
+        )
+        cmd_details = []
 
-        retval = []
-        for command in kwargs.get("commands", []):
-            self.ctx.vlog(f"Preparing to execute command:\n{command}")
+        if kwargs.get("container", None):
+            for command in kwargs.get("commands", []):
+                cmd_details = self._execute_in_container(command, **kwargs)
+        else:
+            for command in kwargs.get("commands", []):
+                cmd_details = self._execute_in_shell(command, **kwargs)
+        return cmd_details
 
-            process = subprocess.Popen(
-                command,
-                shell=True,
-                env=environment,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT,
-                universal_newlines=True,
-            )
+    def _execute_in_shell(self, command="", **kwargs):
+        """
+        Executes a command in the shell.
+        """
 
+        self.ctx.vlog(f"Preparing to execute command in shell:\n{command}")
+
+        cmd_details = []
+        process = subprocess.Popen(
+            command,
+            shell=True,
+            env=kwargs.get("environment", {}),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            universal_newlines=True,
+        )
+
+        if not kwargs.get("suppress_output", False):
+            while True:
+                output = process.stdout.readline()
+                if output == "" and process.poll() is not None:
+                    break
+                if output:
+                    output = self._strip_ansi(str(output))
+                    self.ctx.vlog(output.strip())
+        output, _ = process.communicate()
+        if process.returncode != 0 and kwargs.get("handle_error", True):
+            self.ctx.log_err(f"Failed to execute shell command:\n{command}")
+            sys.exit(1)
+
+        cmd_details.append(
+            {
+                "command": command,
+                "output": self._strip_ansi(str(output)),
+                "return_code": process.returncode,
+            }
+        )
+        return cmd_details
+
+    def _execute_in_container(self, command="", **kwargs):
+        """
+        Executes a command inside of a container through the Docker SDK (similar
+        to docker exec)
+        """
+
+        container = kwargs.get("container", None)
+        self.ctx.vlog(
+            f"Preparing to execute command in container '{container.name}':\n{command}"
+        )
+
+        cmd_details = []
+        docker_client = docker.from_env()
+        api_client = docker.APIClient(version="auto")
+
+        exec_handler = api_client.exec_create(
+            container.name,
+            cmd=command,
+            privileged=True,
+            user=kwargs.get("docker_user", "root"),
+        )
+
+        output = api_client.exec_start(exec_handler, stream=True)
+        output_string = ""
+
+        for line in output:
+            line = self._strip_ansi(line.decode().strip())
+            output_string += line
             if not kwargs.get("suppress_output", False):
-                while True:
-                    output = process.stdout.readline()
-                    if output == "" and process.poll() is not None:
-                        break
-                    if output:
-                        output = self.strip_ansi(output)
-                        self.ctx.vlog(output.strip())
-            output, _ = process.communicate()
-            if process.returncode != 0:
-                if not kwargs.get("handle_error", False):
-                    self.ctx.log_err(f"Failed to execute command:\n{command}")
-                    sys.exit(1)
-
-            retval.append(
-                {
-                    "command": command,
-                    "output": str(output),
-                    "return_code": process.returncode,
-                }
+                self.ctx.vlog(line)
+        return_code = api_client.exec_inspect(exec_handler["Id"]).get("ExitCode")
+        if return_code != 0 and kwargs.get("handle_error", True):
+            self.ctx.log_err(
+                f"Failed to execute command in container '{container.name}':\n{command}"
             )
-        return retval
+            sys.exit(1)
+
+        cmd_details.append(
+            {"command": command, "output": output_string, "return_code": return_code}
+        )
+        return cmd_details
 
     def construct_environment(self, environment={}):
         """Constructs dictionary of environment variables."""
 
         # Remove conflicting keys from host environment; user config and Compose
-        # keys take precendance
+        # config take precendance
         host_environment = os.environ.copy()
         if environment:
             delete = []
@@ -153,7 +213,7 @@ class CommandExecutor(object):
         environment.update(host_environment)
         return environment
 
-    def strip_ansi(self, value=""):
+    def _strip_ansi(self, value=""):
         """Strips ANSI escape sequences from strings."""
 
         # Strip ANSI codes before Click so that our logging helpers
@@ -163,7 +223,7 @@ class CommandExecutor(object):
 
 
 class ComposeEnvironment(object):
-    def __init__(self, ctx, env=[]):
+    def __init__(self, ctx=None, env=[]):
         """
         Creates a string and a dictionary of environment variables for use by
         Docker Compose. Environment variables are sourced from the user's
@@ -224,7 +284,7 @@ class ComposeEnvironment(object):
                     )
                     sys.exit(1)
                 try:
-                    del config_dict[env_variable_list[0].strip()] # remove if present
+                    del config_dict[env_variable_list[0].strip()]  # remove if present
                 except:
                     pass
                 config_dict[env_variable_list[0].strip()] = env_variable_list[1].strip()
@@ -269,7 +329,7 @@ class Modules(object):
 
         return containers, module_label_vals, catalog, security
 
-    def get_running_containers(self, docker_client):
+    def get_running_containers(self, docker_client=None):
         """Gets all running minipresto containers."""
 
         containers = docker_client.containers.list(filters={"label": RESOURCE_LABEL})
@@ -333,7 +393,7 @@ def check_daemon(ctx):
 
 
 @pass_environment
-def validate_module_dirs(ctx, key, modules=[]):
+def validate_module_dirs(ctx, key={}, modules=[]):
     """
     Validates that the directory and Compose .yml exist for each provided
     module. If they all exist, a list of module directories and YAML file paths
@@ -379,7 +439,7 @@ def convert_MultiArgOption_to_list(*args):
     return tuple(retval)
 
 
-def validate_yes_response(response):
+def validate_yes_response(response=""):
     """Validates 'yes' user input."""
 
     response = response.replace(" ", "")

--- a/cli/minipresto/test/test_down.py
+++ b/cli/minipresto/test/test_down.py
@@ -13,8 +13,10 @@ from minipresto.settings import RESOURCE_LABEL
 def main():
     helpers.log_status(__file__)
     helpers.start_docker_daemon()
+    cleanup()
     test_no_containers()
     test_running_containers()
+    test_keep()
 
 
 def test_no_containers():
@@ -23,8 +25,6 @@ def test_no_containers():
     are running.
     """
 
-    # Run preliminary `down` in case a container is running
-    helpers.execute_command(["-v", "down"])
     result = helpers.execute_command(["-v", "down"])
 
     assert result.exit_code == 0
@@ -43,7 +43,6 @@ def test_running_containers():
     Verifies that the down command works when multiple containers are running.
     """
 
-    helpers.execute_command(["-v", "down"])
     helpers.execute_command(["-v", "provision", "--catalog", "test"])
     result = helpers.execute_command(["-v", "down"])
 
@@ -59,6 +58,28 @@ def test_running_containers():
     docker_client = docker.from_env()
     containers = docker_client.containers.list(filters={"label": RESOURCE_LABEL})
     assert len(containers) == 0, "There should be no running containers"
+
+    helpers.log_success(cast(FrameType, currentframe()).f_code.co_name)
+    cleanup()
+
+
+def test_keep():
+    """
+    Verifies that the `--keep` flag works as expected.
+    """
+
+    helpers.execute_command(["-v", "provision", "--catalog", "test"])
+    result = helpers.execute_command(["-v", "down", "--keep"])
+
+    assert "Removed container" not in result.output
+
+    docker_client = docker.from_env()
+    containers = docker_client.containers.list(
+        filters={"label": RESOURCE_LABEL}, all=True
+    )
+
+    for container in containers:
+        assert container.name.lower() == "presto" or container.name.lower() == "test"
 
     helpers.log_success(cast(FrameType, currentframe()).f_code.co_name)
     cleanup()

--- a/cli/minipresto/test/test_down.py
+++ b/cli/minipresto/test/test_down.py
@@ -71,6 +71,7 @@ def test_keep():
     helpers.execute_command(["-v", "provision", "--catalog", "test"])
     result = helpers.execute_command(["-v", "down", "--keep"])
 
+    assert "Stopped container" in result.output
     assert "Removed container" not in result.output
 
     docker_client = docker.from_env()

--- a/cli/minipresto/test/test_down.py
+++ b/cli/minipresto/test/test_down.py
@@ -49,7 +49,8 @@ def test_running_containers():
     assert result.exit_code == 0
     assert all(
         (
-            "Stopped/removed container" in result.output,
+            "Stopped container" in result.output,
+            "Removed container" in result.output,
             "test" in result.output,
             "presto" in result.output,
         )

--- a/cli/minipresto/test/test_remove.py
+++ b/cli/minipresto/test/test_remove.py
@@ -5,9 +5,12 @@ import docker
 import subprocess
 import minipresto.test.helpers as helpers
 
+from minipresto.settings import RESOURCE_LABEL
 from inspect import currentframe
 from types import FrameType
 from typing import cast
+
+docker_client = docker.from_env()
 
 
 def main():
@@ -26,7 +29,8 @@ def main():
 
 def test_images():
     """
-    Verifies that images with the minipresto label applied to them are removed.
+    Verifies that images with the standard minipresto label applied to them are
+    removed.
     """
 
     helpers.execute_command(["provision", "--catalog", "test"])
@@ -36,11 +40,13 @@ def test_images():
     assert result.exit_code == 0
     assert "Image removed:" in result.output
 
-    docker_client = docker.from_env()
-    images = docker_client.images.list(
-        filters={"label": "com.starburst.tests.module.test=catalog-test"}
+    assert_docker_resource_count(
+        {
+            "resource_type": docker_client.images,
+            "label": RESOURCE_LABEL,
+            "expected_count": 0,
+        }
     )
-    assert len(images) == 0
 
     helpers.log_success(cast(FrameType, currentframe()).f_code.co_name)
     cleanup()
@@ -48,7 +54,8 @@ def test_images():
 
 def test_volumes():
     """
-    Verifies that volumes with the minipresto label applied to them are removed.
+    Verifies that volumes with the standard minipresto label applied to them are
+    removed.
     """
 
     helpers.execute_command(["provision", "--catalog", "test"])
@@ -58,11 +65,13 @@ def test_volumes():
     assert result.exit_code == 0
     assert "Volume removed:" in result.output
 
-    docker_client = docker.from_env()
-    volumes = docker_client.volumes.list(
-        filters={"label": "com.starburst.tests.module.test=catalog-test"}
+    assert_docker_resource_count(
+        {
+            "resource_type": docker_client.volumes,
+            "label": RESOURCE_LABEL,
+            "expected_count": 0,
+        }
     )
-    assert len(volumes) == 0
 
     helpers.log_success(cast(FrameType, currentframe()).f_code.co_name)
     cleanup()
@@ -70,7 +79,7 @@ def test_volumes():
 
 def test_label():
     """
-    Verifies that images with the minipresto label applied to them are removed.
+    Verifies that only images with the given label are removed.
     """
 
     helpers.execute_command(["provision", "--catalog", "test"])
@@ -88,11 +97,18 @@ def test_label():
     assert result.exit_code == 0
     assert "Image removed:" in result.output
 
-    docker_client = docker.from_env()
-    images = docker_client.images.list(
-        filters={"label": "com.starburst.tests.module.test=catalog-test"}
+    assert_docker_resource_count(
+        {
+            "resource_type": docker_client.images,
+            "label": "com.starburst.tests.module.test=catalog-test",
+            "expected_count": 0,
+        },
+        {
+            "resource_type": docker_client.images,
+            "label": "com.starburst.tests.module=presto",
+            "expected_count": 1,
+        },
     )
-    assert len(images) == 0
 
     helpers.log_success(cast(FrameType, currentframe()).f_code.co_name)
     cleanup()
@@ -100,7 +116,7 @@ def test_label():
 
 def test_multiple_labels():
     """
-    Verifies that images with the minipresto label applied to them are removed.
+    Verifies that images with any of the given labels are removed.
     """
 
     helpers.execute_command(["provision", "--catalog", "test"])
@@ -112,18 +128,25 @@ def test_multiple_labels():
             "--volumes",
             "--label",
             "com.starburst.tests.module.test=catalog-test",
-            "com.starburst.tests=minipresto",
+            RESOURCE_LABEL,
         ],
     )
 
     assert result.exit_code == 0
     assert "Volume removed:" in result.output
 
-    docker_client = docker.from_env()
-    volumes = docker_client.volumes.list(
-        filters={"label": "com.starburst.tests.module.test=catalog-test"}
+    assert_docker_resource_count(
+        {
+            "resource_type": docker_client.volumes,
+            "label": RESOURCE_LABEL,
+            "expected_count": 0,
+        },
+        {
+            "resource_type": docker_client.volumes,
+            "label": "com.starburst.tests.module.test=catalog-test",
+            "expected_count": 0,
+        },
     )
-    assert len(volumes) == 0
 
     helpers.log_success(cast(FrameType, currentframe()).f_code.co_name)
     cleanup()
@@ -143,6 +166,14 @@ def test_invalid_label():
     assert result.exit_code == 0
     assert "Image removed:" not in result.output
 
+    assert_docker_resource_count(
+        {
+            "resource_type": docker_client.images,
+            "label": "com.starburst.tests.module.test=catalog-test",
+            "expected_count": 1,
+        }
+    )
+
     helpers.log_success(cast(FrameType, currentframe()).f_code.co_name)
     cleanup()
 
@@ -158,6 +189,19 @@ def test_all():
 
     assert result.exit_code == 0
     assert all(("Volume removed:" in result.output, "Image removed:" in result.output))
+
+    assert_docker_resource_count(
+        {
+            "resource_type": docker_client.images,
+            "label": RESOURCE_LABEL,
+            "expected_count": 0,
+        },
+        {
+            "resource_type": docker_client.volumes,
+            "label": RESOURCE_LABEL,
+            "expected_count": 0,
+        },
+    )
 
     helpers.log_success(cast(FrameType, currentframe()).f_code.co_name)
     cleanup()
@@ -178,6 +222,19 @@ def test_remove_dependent_resources_running():
             "Cannot remove volume:" in result.output,
             "Cannot remove image:" in result.output,
         )
+    )
+
+    assert_docker_resource_count(
+        {
+            "resource_type": docker_client.images,
+            "label": "com.starburst.tests.module.test=catalog-test",
+            "expected_count": 1,
+        },
+        {
+            "resource_type": docker_client.volumes,
+            "label": "com.starburst.tests.module.test=catalog-test",
+            "expected_count": 1,
+        },
     )
 
     helpers.log_success(cast(FrameType, currentframe()).f_code.co_name)
@@ -204,7 +261,25 @@ def test_remove_dependent_resources_stopped():
     )
 
     assert result.exit_code == 0
-    assert "Cannot remove volume:" in result.output
+    assert all(
+        (
+            "Cannot remove volume:" in result.output,
+            "Cannot remove image:" in result.output,
+        )
+    )
+
+    assert_docker_resource_count(
+        {
+            "resource_type": docker_client.images,
+            "label": "com.starburst.tests.module.test=catalog-test",
+            "expected_count": 1,
+        },
+        {
+            "resource_type": docker_client.volumes,
+            "label": "com.starburst.tests.module.test=catalog-test",
+            "expected_count": 1,
+        },
+    )
 
     helpers.log_success(cast(FrameType, currentframe()).f_code.co_name)
     cleanup()
@@ -237,8 +312,40 @@ def test_remove_dependent_resources_force():
     assert result.exit_code == 0
     assert "Image removed:" in result.output
 
+    assert_docker_resource_count(
+        {
+            "resource_type": docker_client.images,
+            "label": "com.starburst.tests.module.test=catalog-test",
+            "expected_count": 0,
+        },
+        {
+            "resource_type": docker_client.volumes,
+            "label": "com.starburst.tests.module.test=catalog-test",
+            "expected_count": 1,
+        },
+    )
+
     helpers.log_success(cast(FrameType, currentframe()).f_code.co_name)
     cleanup()
+
+
+def assert_docker_resource_count(*args):
+    """
+    Asserts the accuracy of the count returned from a Docker resource lookup.
+    Accepts variable number of dictionaries and will perform processing for each
+    dictionary.
+
+    - `resource_type`: Resource type (container, volume, image)
+    - `label`: Label to filter by
+    - `expected_count`: The expected length of the returned list
+    """
+
+    for arg in args:
+        resource_type = arg.get("resource_type", None)
+        label = arg.get("label", None)
+        expected_count = arg.get("expected_count", None)
+        resource_list = resource_type.list(filters={"label": label})
+        assert len(resource_list) == expected_count
 
 
 def cleanup():

--- a/readme.md
+++ b/readme.md
@@ -47,7 +47,7 @@ You can provision an environment via the `provision` command.
   - `--docker-native`: Appends the constructed Compose command with native Docker Compose CLI options. Can be none, one, or many. To use this, simply pass in additional Docker Compose options, i.e. `minipresto provision --docker-native '--remove-orphans --force-recreate'` or `minipresto provision -d --build`. 
     - When passing multiple parameters to this option, the list needs to be space-delimited and surrounded with double or single quotes.
 - If no options are passed in, the CLI will provision a standalone Presto container.
-- The command cannot currently be used to append additional modules to an active environment. To modify an environment, first shut it down, then reprovision with the needed modules.
+- The command cannot currently be used to append additional modules to an active environment. To modify an environment, first shut it down, then re-provision with the needed modules.
 
 Sample `provision` commands:
 
@@ -424,6 +424,10 @@ If you need to build a custom image, you can do so and structure the Compose fil
 
 ### Bootstrap Scripts
 Minipresto supports container bootstrap scripts. These scripts **do not replace** the entrypoint (or default command) for a given container. The script is copied from the Minipresto library to the container, executed, and then removed from the container. Containers are restarted after each bootstrap script execution, **so the bootstrap scripts themselves should not restart the container**.
+
+If a bootstrap script has executed in a container and the unnamed volume associated with the container still exists, Minipresto will not re-execute the bootstrap script unless the contents of the script have changed. The is useful after running `minipresto down --keep` (which does not remove unnamed volumes associated with the containers), so that the subsequent provisioning command will not re-execute the same bootstrap script(s).
+
+If a bootstrap script is updated, it is recommended to destroy the associated container(s) via `minipresto down` and then to re-provision.
 
 To add a bootstrap script, simply add a `resources/bootstrap/` directory in any given module, create a shell script, and then reference the script name in the Compose YAML file:
 

--- a/readme.md
+++ b/readme.md
@@ -89,6 +89,7 @@ minipresto -v remove --volumes --label com.starburst.tests.module.postgres=catal
 You can shut down an active environment with the `down` command.
 
 - `down`: Stops and removes all running Minipresto containers (exactly what `docker-compose down` does).
+  - `--keep`: Prevents the removal from containers; with this flag, containers will only be stopped, preserving any unnamed container volumes. Defaults to `False`.
 
 Sample `down` command:
 


### PR DESCRIPTION
- Add `--keep` option to `down` command and associated test. This will retain any unnamed volumes associated with the containers that are stopped.
- Add functionality and associated test to the `provision` command which checks if a bootstrap script has already executed inside of a container. It grabs the checksum of the file prior to executing, then checks if that same checksum exists in the `bootstrap_status.txt` file in `/opt/minipresto/`. 
- Updated readme with info regarding the new functionality.
- Added `suppress_output` option to the `execute_commands` method of `CommandExecutor`.
- Separated functions to execute commands in the shell and inside of Docker containers, so now there is support for both options.
- Fixed a bug that would pass an empty label to the `remove` command if no label was passed to the command.
- Updated tests for the `remove` command.