### PR TITLE
Functional Updates

### DIFF
--- a/cli/minipresto/commands/cmd_provision.py
+++ b/cli/minipresto/commands/cmd_provision.py
@@ -454,6 +454,7 @@ def check_license(ctx, compose_environment={}):
             "No Starburst license. Not copying to Presto container.",
             level=LogLevel().verbose,
         )
+        return
 
     command_executor = CommandExecutor(ctx)
     ctx.log(

--- a/cli/minipresto/commands/cmd_provision.py
+++ b/cli/minipresto/commands/cmd_provision.py
@@ -445,9 +445,19 @@ def check_license(ctx, compose_environment={}):
     exists.
     """
 
-    starburst_lic_file = ctx.get_config_value(
-        "PRESTO", "STARBURST_LIC_PATH", warn=False, default=""
-    ).strip()
+    # Check if added from `--env` option (will only be in the compose env if
+    # added - it is not a [MODULES] section variable, so it is not added to the
+    # dict by default)
+    # 
+    # TODO: Multipurpose ComposeEnvironment for this exact
+    # reason. 
+    starburst_lic_file = compose_environment.compose_env_dict.get("STARBURST_LIC_PATH", "")
+
+    # Check config file
+    if not starburst_lic_file:
+        starburst_lic_file = ctx.get_config_value(
+            "PRESTO", "STARBURST_LIC_PATH", warn=False, default=""
+        ).strip()
 
     if not os.path.isfile(starburst_lic_file):
         ctx.log(

--- a/cli/minipresto/core.py
+++ b/cli/minipresto/core.py
@@ -453,7 +453,7 @@ def handle_exception(ctx, e=MiniprestoException, log_msg=True, sys_exit=True):
         ctx.log(e.msg, level=LogLevel().error)
 
     if ctx.verbose:
-        print(f"\n{traceback.format_exc()}")
+        click.echo(f"\n{traceback.format_exc()}", err=True)
 
     if sys_exit:
         sys.exit(e.exit_code)
@@ -481,7 +481,7 @@ def handle_generic_exception(ctx, e=Exception, log_msg=True, sys_exit=True):
         ctx.log(str(e), level=LogLevel().error)
 
     if ctx.verbose:
-        print(f"\n{traceback.format_exc()}")
+        click.echo(f"\n{traceback.format_exc()}", err=True)
 
     if sys_exit:
         sys.exit(1)

--- a/cli/minipresto/settings.py
+++ b/cli/minipresto/settings.py
@@ -70,10 +70,14 @@ SNOWFLAKE_JDBC_STAGE_SCHEMA=
 PROVISION_SNAPSHOT_TEMPLATE = """
 #!/usr/bin/env bash
 
-# ------------------------------------------------------------------------------
-# Below is the exact command used to provision the snapshotted environment. Run
-# this command in your terminal to reproduce the exact state of the environment.
-# ------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------------
+# Below is the exact command used to provision the snapshotted environment. Run this 
+# command in your terminal to reproduce the exact state of the environment.
+#
+# If you need config data from the snapshot's 'minipresto.cfg' file, you will either 
+# need to copy it from the snapshot directory to '~./minipresto/minipresto.cfg' or 
+# individually copy the needed configs to your existing 'minipresto.cfg' file. 
+# ------------------------------------------------------------------------------------
 
 
 """


### PR DESCRIPTION
- Change stack trace logging method to `click.echo()`
- Add comment about `minipresto.cfg` in the snapshot provision command template string
- Exit function at appropriate time if there is no license file