### PR TITLE
Update install.sh script to include all python versions 3.8+

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 
 function install() {
-    if pip --version 2>&1 | grep -q -e "python3.[6-9]" -e "python 3.[6-9]"; then
+    if pip --version 2>&1 | grep -q -e "python.*3.[8-9]" -e "python.*3.[1][0-1]"; then
         PIP=pip
-    elif pip3 --version 2>&1 | grep -q -e "python3.[6-9]" -e "python 3.[6-9]"; then
+    elif pip3 --version 2>&1 | grep -q -e "python.*3.[8-9]" -e "python.*3.[1][0-1]"; then
         PIP=pip3
     else
-        echo "Minitrino requires Python 3.6+. Please install a compatible Python version and ensure Pip points to it."
+        echo "Minitrino requires Python 3.8+. Please install a compatible Python version and ensure Pip points to it."
         exit 1
     fi
 


### PR DESCRIPTION
As [Minitrino requirements](https://github.com/jefflester/minitrino#requirements) state Python version must be 3.8+, this PR addresses changes to the install script to account for these newer versions as raised in https://github.com/jefflester/minitrino/issues/43

Grep regex has been to account for newer [python versions](https://www.python.org/doc/versions/) 
- Regex to match versions 3.8-3.9 - `python.*3.[8-9]`
- Regex to match versions 3.10-3.11 - `python.*3.[1][0-1]`