### PR TITLE
Add `internal-communication.shared-secret` to config.properties in Dockerfile

### DIFF
--- a/lib/Dockerfile
+++ b/lib/Dockerfile
@@ -10,6 +10,7 @@ ADD ./dockerfile-resources/configure.sh /opt/minitrino/
 
 USER root
 RUN set -euxo pipefail \
+    && echo "internal-communication.shared-secret=minitrinoRocks15" >> /etc/starburst/config.properties \
     && chmod +x /opt/minitrino/configure.sh \
     && /opt/minitrino/configure.sh
 


### PR DESCRIPTION
As mentioned in [Issue 42](https://github.com/jefflester/minitrino/issues/42), the property [internal-communication.shared-secret](https://docs.starburst.io/latest/security/internal-communication.html) is required if authentication is enabled on your SEP cluster. 

This PR adds the configuration property/value `internal-communication.shared-secret=minitrinoRocks15` to /etc/starburst/config.properties in the `Dockerfile` to ensure this property is included with the base image at start up. 