### PR TITLE
Add BIAC module

### DIFF
--- a/lib/docker-compose.yml
+++ b/lib/docker-compose.yml
@@ -18,6 +18,6 @@ services:
     # Uncomment this to enable the volume mount. The variable should point to a
     # valid SEP license. 
     # volumes:
-    #   - "${STARBURST_LIC_PATH}:/etc/starburst/starburstdata.license:ro"
+    #  - "${STARBURST_LIC_PATH}:/etc/starburst/starburstdata.license:ro"
     ports:
       - "8080:8080"

--- a/lib/docker-compose.yml
+++ b/lib/docker-compose.yml
@@ -18,6 +18,6 @@ services:
     # Uncomment this to enable the volume mount. The variable should point to a
     # valid SEP license. 
     # volumes:
-    #  - "${STARBURST_LIC_PATH}:/etc/starburst/starburstdata.license:ro"
+    #   - "${STARBURST_LIC_PATH}:/etc/starburst/starburstdata.license:ro"
     ports:
       - "8080:8080"

--- a/lib/modules/security/biac/biac.yml
+++ b/lib/modules/security/biac/biac.yml
@@ -1,0 +1,15 @@
+version: "3.8"
+services:
+
+  trino:
+    environment: 
+      CONFIG_PROPERTIES: |-
+        starburst.access-control.enabled=true
+        starburst.access-control.audit.enabled=true
+        starburst.access-control.authorized-users=starburst_service,admin
+        starburst.access-control.authorized-groups=admins,sepadmins
+        access-control.config-files=/etc/starburst/biac.properties
+    labels:
+      - "com.starburst.tests.module.biac=security-biac"
+    volumes:
+      - "./modules/security/biac/resources/trino/biac.properties:/etc/starburst/biac.properties"

--- a/lib/modules/security/biac/metadata.json
+++ b/lib/modules/security/biac/metadata.json
@@ -1,0 +1,6 @@
+{
+  "description": "Enables Built-in access control (BIAC) for use in configuring access to the SEP UI",
+  "incompatibleModules": [],
+  "dependentModules": ["insights"],
+  "enterprise": true
+}

--- a/lib/modules/security/biac/readme.md
+++ b/lib/modules/security/biac/readme.md
@@ -1,0 +1,102 @@
+# Built-in Access Control (BIAC) Module
+
+This module configures Trino to enable the built-in access control (BIAC) system
+integrated with the SEP web UI.  
+
+This module can be used in conjunction with the `password-file` and `ldap`
+security modules to provide usernames.  
+
+## Usage
+
+    minitrino --env STARBURST_VER=<ver> provision --module biac  
+
+### Usage with Delta Lake or Hive modules  
+
+Additional configuration is required for use of BIAC with the `Delta Lake` and
+`Hive` object storage catalogs.  
+
+**Delta Lake**: Add the following property to `delta.properties`:
+
+    delta.security=starburst
+
+**Hive**: Add the following property to `hive.properties`:  
+
+    hive.security=starburst
+
+## Accessing Roles and Privileges in the SEP UI  
+
+Standalone BIAC:  
+- Open a web browser and go to [http://localhost:8080](http://localhost:8080)
+- Sign in using a username for an authorized user (Default: `admin`,
+  `starburst_service`)
+- Click on your username in the top right corner > switch role > `sysadmin`  
+
+BIAC with `password-file` or `ldap` module:  
+- Open a web browser and go to [https://localhost:8443](https://localhost:8443)  
+- Have the browser accept the self-signed certificate:  
+  - **Chrome**: Click anywhere on the page and type `thisisunsafe`
+  - **Firefox**: Click on the Advanced button and then click on **Accept the
+    Risk and Continue**.
+  - **Safari**: Click on the button **Show Details** and then click the link
+    **visit this website**.
+- Sign in using a username/password for an authorized user (`admin /
+  trinoRocks15`)
+- Click on your username in the top right corner > switch role > `sysadmin`
+
+## Using the SEP REST API with BIAC 
+
+You can manage BIAC entities and their actions via the SEP REST API (BIAC
+endpoints are of the form `/api/v1/biac/...`). See the list of available
+endpoints and methods in our [API
+Documentation](https://docs.starburst.io/latest/api/index.html#api-_).  
+
+Note: The SEP REST API can only be used for clusters secured with `PASSWORD`
+authentication. To test using the BIAC REST API endpoints, ensure the BIAC
+module has been provisioned in conjunction with the `password-file` or `ldap`
+module.  
+
+### Example 1: List Roles  
+
+    curl -k --location \
+    -X GET 'https://localhost:8443/api/v1/biac/roles' \
+    -H 'Accept: application/json' \
+    -H 'Content-Type: application/json' \
+    -H 'X-Trino-Role: system=ROLE{sysadmin}' \
+    -u 'admin:trinoRocks15'  
+
+### Example 2: Adding a user to authorized users  
+
+The following API POST request adds user `Alice` to authorized users. After
+performing the following successfully, Alice will be able to access BIAC
+features in the SEP UI. 
+
+    curl -k --location \
+    -X POST 'https://localhost:8443/api/v1/biac/subjects/users/alice/assignments' \
+    -H 'Accept: application/json' \
+    -H 'Content-Type: application/json' \
+    -H 'X-Trino-Role: system=ROLE{sysadmin}' \
+    -u 'admin:trinoRocks15' \
+    -d '{ "roleId":"-2", "roleAdmin":"true"}'
+
+### Example 3: Get Role Assignments for a Role
+
+The following API GET request returns users/groups assigned to the `sysadmin`
+role which is defined by `roleId=-1`.  
+
+    curl -k --location \
+    -X GET 'https://localhost:8443/api/v1/biac/roles/-2/assignments?pageToken=&pageSize=&pageSort=' \
+    -H 'Accept: application/json' \
+    -H 'Content-Type: application/json' \
+    -H 'X-Trino-Role: system=ROLE{sysadmin}' \
+    -u 'admin:trinoRocks15'
+
+
+### Example 4: Create Role
+
+    curl -k --location \
+    -X POST 'https://localhost:8443/api/v1/biac/roles' \
+    -H 'Accept: application/json' \
+    -H 'Content-Type: application/json' \
+    -H 'X-Trino-Role: system=ROLE{sysadmin}' \
+    -u 'admin:trinoRocks15' \
+    -d '{ "name": "testRole", "description":"test creating new BIAC role"}'

--- a/lib/modules/security/biac/resources/trino/biac.properties
+++ b/lib/modules/security/biac/resources/trino/biac.properties
@@ -1,0 +1,2 @@
+#for use with multiple access control systems
+access-control.name=starburst

--- a/lib/modules/security/ldap/resources/ldap/ldap-users/admin.ldif
+++ b/lib/modules/security/ldap/resources/ldap/ldap-users/admin.ldif
@@ -1,0 +1,12 @@
+# admin, example.com
+dn: uid=admin,dc=example,dc=com
+changetype: add
+uid: admin
+objectClass: inetOrgPerson
+objectClass: organizationalPerson
+objectClass: person
+objectClass: top
+cn: admin
+sn: admin
+mail: admin@example.com
+userPassword: trinoRocks15

--- a/lib/modules/security/password-file/resources/bootstrap/bootstrap-trino.sh
+++ b/lib/modules/security/password-file/resources/bootstrap/bootstrap-trino.sh
@@ -5,3 +5,4 @@ set -euxo pipefail
 echo "Setting up password file..."
 htpasswd -cbB -C 10 /etc/starburst/password.db alice trinoRocks15
 htpasswd -bB -C 10 /etc/starburst/password.db bob trinoRocks15
+htpasswd -bB -C 10 /etc/starburst/password.db admin trinoRocks15


### PR DESCRIPTION
Adds Built-in access control (BIAC) module as described in [our documentation](https://docs.starburst.io/latest/security/biac-privileges.html#security-biac-privileges--page-root) to security modules. 

- Also adds admin/trinoRocks15 user/password to both `password-file` and `ldap` modules for accessing BIAC controls in SEP UI when used in conjunction with these modules
- Read me contains examples on using the SEP REST API for managing BIAC entities and their actions