### PR TITLE
2.1.4-release-fix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,9 +75,24 @@ jobs:
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
-        run: twine upload src/cli/dist/*
+        run: |-
+          if python -m twine check "https://pypi.org/pypi/minitrino/${PACKAGE_VERSION}/json" | grep -q "404 Not Found"; then
+            twine upload src/cli/dist/*
+          else
+            echo "Package version ${GITHUB_HEAD_REF} already exists on PyPI. Skipping upload."
+          fi
       - name: Check package
         run: |-
+          MAX_ATTEMPTS=5
+          ATTEMPT=1
           pip uninstall -y minitrino
-          pip install minitrino==${GITHUB_HEAD_REF}
+          until pip install minitrino==${GITHUB_HEAD_REF} --no-cache-dir; do
+            if [ $ATTEMPT -ge $MAX_ATTEMPTS ]; then
+              echo "Failed to install the latest version after $ATTEMPT attempts."
+              exit 1
+            fi
+            echo "Attempt $ATTEMPT failed. Retrying in 30 seconds..."
+            ATTEMPT=$((ATTEMPT+1))
+            sleep 30
+          done
           minitrino --help || exit 1


### PR DESCRIPTION
# Minitrino Release Notes: 2.1.4

## Release Overview

- [Minitrino Release Notes: 2.1.4](#minitrino-release-notes-214)
  - [Release Overview](#release-overview)
  - [CLI Changes and Additions](#cli-changes-and-additions)
  - [Library Changes and Additions](#library-changes-and-additions)
  - [Other](#other)

Given that there were three releases in 24 hours, these release notes include
the release notes from the prior two releases, `2.1.2` and `2.1.3`.

## CLI Changes and Additions

- Updated package dependencies (#77)
- Added `pyproject.toml` to handle build dependencies (#75)
- Updated `lib-install` command to use updated GitHub API path when fetching
  release artifact
- Added the ability to provision worker nodes; added relevant CLI tests
- Containers now restart in parallel when necessary when using the `provision`
  command
- The `down` command now parallelizes stopping and removing containers

## Library Changes and Additions

- Added support for latest LTSs by adding Java 22 support to the base image
  (#76)
- Made adjustments to the following modules for compatibility with >= 453-e:
  - Bumped `POSTGRES_SEP_BACKEND_SVC_VER` to version `12`
    - Affected module(s): `insights`
  - Updated truststore (`cacerts`) imports to be portable across all Java
  versions; improved directory naming of TLS resources (certs, truststores,
  etc.)
    - Affected module(s): `tls`, `password-file`, `ldap`, `oauth2`
- Added tests with the new `--worker` argument for all modules

## Other

- Improved `install.sh` script (#75)
- Added automatic image removal to preserve disk space on GHA runner
