### PR TITLE
Update repo `install.sh` script & fix various issues

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -11,8 +11,8 @@ for arg in "$@"; do
 done
 
 find_python() {
-    for py in python python3 /opt/homebrew/bin/python3 /usr/local/bin/python3; do
-        if type "${py}" >/dev/null 2>&1; then
+    for py in python3 python /opt/homebrew/bin/python3 /usr/local/bin/python3 /usr/bin/python3; do
+        if command -v "${py}" >/dev/null 2>&1; then
             version=$("${py}" -c 'import sys; print(f"{sys.version_info[0]}.{sys.version_info[1]}")')
             echo "Detected Python version: ${version} (${py})"
             case "${version}" in

--- a/install.sh
+++ b/install.sh
@@ -1,39 +1,174 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
-function install() {
-    # Find a compatible version of pip
-    if command -v pip &>/dev/null && pip --version 2>&1 | grep -q -E "python.*3\.[8-9]|python.*3\.(1[0-9])"; then
-        PIP=pip
-    elif command -v pip3 &>/dev/null && pip3 --version 2>&1 | grep -q -E "python.*3\.[8-9]|python.*3\.(1[0-9])"; then
-        PIP=pip3
-    else
-        echo "Minitrino requires Python 3.8+. Please install a compatible Python version and ensure Pip points to it."
-        exit 1
+set -eu
+
+NO_VENV=0
+for arg in "$@"; do
+    if [ "$arg" = "--no-venv" ]; then
+        NO_VENV=1
+        break
     fi
+done
 
-    # Set verbose if "-v" is passed
-    if [[ $1 == "-v" ]]; then
-        set -ex
-    else
-        set -e
-    fi
-
-    # Get the directory of the script
-    SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-
-    # Check for pyproject.toml dependencies
-    "${PIP}" install -q --upgrade pip setuptools wheel
-
-    echo "Installing Minitrino CLI and test modules..."
-    "${PIP}" install -q --editable "${SCRIPT_DIR}/src/cli/" --use-pep517
-    "${PIP}" install -q --editable "${SCRIPT_DIR}/src/test/" --use-pep517
-
+find_python() {
+    for py in python python3 /opt/homebrew/bin/python3 /usr/local/bin/python3; do
+        if type "${py}" >/dev/null 2>&1; then
+            version=$("${py}" -c 'import sys; print(f"{sys.version_info[0]}.{sys.version_info[1]}")')
+            echo "Detected Python version: ${version} (${py})"
+            case "${version}" in
+                3.8|3.9|3.1[0-9])
+                    PYTHON="${py}"
+                    return
+                    ;;
+            esac
+        fi
+    done
+    echo "Error: Python 3.8+ is required but not found." >&2
+    exit 1
 }
 
-time install "$1"
+check_wsl() {
+    if [ "$(uname -s)" = "Linux" ] && grep -qEi "(Microsoft|WSL)" /proc/version 2>/dev/null; then
+        echo "Note: You're running inside WSL. Make sure Docker Desktop is installed and WSL integration is enabled."
+    fi
+}
 
-echo -e "\nInstallation complete! Start with the CLI by configuring it with 'minitrino config' \
-(you can do this later). Alternatively, get started immediately with 'minitrino provision'.\n"
+check_pip() {
+    if ! "${PYTHON}" -m pip --version >/dev/null 2>&1; then
+        echo "Error: Pip is not available for ${PYTHON}. Please install pip."
+        exit 1
+    fi
+}
+
+check_docker() {
+    if ! command -v docker >/dev/null 2>&1; then
+        echo "Error: Docker is required but not installed or not in your PATH."
+        exit 1
+    fi
+}
+
+handle_managed_python() {
+    if [ "${NO_VENV}" -eq 1 ]; then
+        echo "Skipping virtual environment setup due to --no-venv flag."
+        return
+    fi
+
+    if [ -z "${VIRTUAL_ENV:-}" ]; then
+        echo "Checking if pip install is blocked (PEP 668)..."
+        if ! "${PYTHON}" -m pip install --dry-run --upgrade pip >/dev/null 2>&1; then
+            echo "Detected a managed Python environment (PEP 668 or similar)."
+            echo "Creating a virtual environment in ./venv..."
+            "${PYTHON}" -m venv "${SCRIPT_DIR}/venv"
+            echo "Re-running install.sh using the virtual environment..."
+            . "${SCRIPT_DIR}/venv/bin/activate"
+            exec "${SCRIPT_PATH}" "$@"
+        fi
+    fi
+}
+
+pip_install() {
+    if [ -z "${VIRTUAL_ENV:-}" ] && [ "$(id -u)" -ne 0 ]; then
+        pip_args="--user"
+    else
+        pip_args=""
+    fi
+
+    echo "Installing editable CLI and test modules from source..."
+    "${PYTHON}" -m pip install ${pip_args} --disable-pip-version-check --upgrade pip setuptools wheel || {
+        echo "Error: Failed to upgrade pip, setuptools, or wheel"
+        exit 1
+    }
+
+    "${PYTHON}" -m pip install ${pip_args} --editable "${SCRIPT_DIR}/src/cli/" --use-pep517 || {
+        echo "Error: Failed to install CLI module"
+        exit 1
+    }
+
+    "${PYTHON}" -m pip install ${pip_args} --editable "${SCRIPT_DIR}/src/test/" --use-pep517 || {
+        echo "Error: Failed to install test module"
+        exit 1
+    }
+}
+
+handle_path_and_symlink() {
+    MINITRINO_BIN=$(command -v minitrino 2>/dev/null || "${PYTHON}" -c "import os; print(os.path.realpath('${SCRIPT_DIR}/venv/bin/minitrino'))")
+    TARGET_BIN_DIR="${HOME}/.local/bin"
+
+    mkdir -p "${TARGET_BIN_DIR}"
+
+    if ln -sf "${MINITRINO_BIN}" "${TARGET_BIN_DIR}/minitrino"; then
+        echo "Symlinked minitrino to: ${TARGET_BIN_DIR}/minitrino"
+
+        case ":${PATH}:" in
+            *":${TARGET_BIN_DIR}:"*) ;; # already in PATH
+            *)
+                export PATH="${TARGET_BIN_DIR}:${PATH}"
+                echo "Note: ${TARGET_BIN_DIR} was added to your PATH for this session."
+
+                USER_SHELL=$(basename "${SHELL:-$0}")
+                case "${USER_SHELL}" in
+                    bash)
+                        echo "To make it permanent, add this line to one of the following (depending on your setup):"
+                        echo "  export PATH=\"\$HOME/.local/bin:\$PATH\""
+                        echo "  ~/.bash_profile  (macOS default login shell)"
+                        echo "  ~/.bashrc        (Linux interactive shells)"
+                        echo "  ~/.profile       (fallback on some systems)"
+                        ;;
+                    zsh)
+                        echo "To make it permanent, add this to your ~/.zprofile or ~/.zshrc:"
+                        echo "  export PATH=\"\$HOME/.local/bin:\$PATH\""
+                        ;;
+                    *)
+                        echo "To make it permanent, add this to your shell config (e.g., ~/.profile):"
+                        echo "  export PATH=\"\$HOME/.local/bin:\$PATH\""
+                        ;;
+                esac
+                ;;
+        esac
+    else
+        echo "Error: Failed to create symlink to ${TARGET_BIN_DIR}"
+        echo "You can run minitrino directly from:"
+        echo "  ${MINITRINO_BIN}"
+        return 1
+    fi
+}
+
+check_install() {
+    hash -r 2>/dev/null || true
+    if ! command -v minitrino >/dev/null 2>&1; then
+        echo "Warning: 'minitrino' is installed but not found in your shell."
+        echo "Try running this instead:"
+        echo "  ${MINITRINO_BIN}"
+    else
+        echo "'minitrino' is now available in your PATH (via ~/.local/bin)."
+    fi
+}
+
+install() {
+    [ "${1:-}" = "-v" ] && set -eux
+
+    if command -v realpath >/dev/null 2>&1; then
+        SCRIPT_PATH=$(realpath "$0")
+    else
+        SCRIPT_PATH=$(python -c "import os; print(os.path.realpath('$0'))")
+    fi
+    SCRIPT_DIR=$(dirname "${SCRIPT_PATH}")
+
+    find_python
+    check_wsl
+    check_pip
+    check_docker
+    handle_managed_python "$@"
+    pip_install
+    handle_path_and_symlink
+    check_install
+}
+
+time install "$@"
+
+echo "
+Installation complete! Start with the CLI by configuring it with 'minitrino config'.
+Alternatively, get started immediately with 'minitrino provision'.
+"
 
 minitrino
-echo -e "\n"

--- a/release-notes/3.0.0.md
+++ b/release-notes/3.0.0.md
@@ -1,0 +1,21 @@
+# Minitrino Release Notes: 3.0.0
+
+## Release Overview
+
+- [Minitrino Release Notes: 3.0.0](#minitrino-release-notes-300)
+  - [Release Overview](#release-overview)
+  - [CLI Changes and Additions](#cli-changes-and-additions)
+  - [Library Changes and Additions](#library-changes-and-additions)
+  - [Other](#other)
+
+## CLI Changes and Additions
+
+- N/A
+
+## Library Changes and Additions
+
+- N/A
+
+## Other
+
+- N/A

--- a/src/cli/minitrino/settings.py
+++ b/src/cli/minitrino/settings.py
@@ -17,8 +17,8 @@ MODULE_RESOURCES = "resources"
 MIN_CLUSTER_VER = 443
 ETC_DIR = "/etc/${CLUSTER_DIST}"
 LIC_VOLUME_MOUNT = "${LIC_PATH}:${LIC_MOUNT_PATH}"
-LIC_MOUNT_PATH = f"{ETC_DIR}/starburstdata.license:ro"
-DUMMY_LIC_MOUNT_PATH = f"{ETC_DIR}/dummy.license:ro"
+LIC_MOUNT_PATH = f"/etc/starburst/starburstdata.license:ro"
+DUMMY_LIC_MOUNT_PATH = f"/etc/starburst/dummy.license:ro"
 CLUSTER_CONFIG = "config.properties"
 CLUSTER_JVM_CONFIG = "jvm.config"
 

--- a/src/lib/image/src/scripts/install-java.sh
+++ b/src/lib/image/src/scripts/install-java.sh
@@ -15,7 +15,7 @@ TRINO_VER="${CLUSTER_VER:0:3}"
 if [ "${TRINO_VER}" -ge 436 ] && [ "${TRINO_VER}" -le 446 ]; then
     JAVA_VER=21.0.5
 elif [ "${TRINO_VER}" -ge 447 ] && [ "${TRINO_VER}" -le 463 ]; then
-    JAVA_VER=22.0.1
+    JAVA_VER=22.0.2
 elif [ "${TRINO_VER}" -ge 464 ]; then
     JAVA_VER=23.0.2
 else

--- a/src/lib/image/src/scripts/install.sh
+++ b/src/lib/image/src/scripts/install.sh
@@ -88,6 +88,7 @@ prune_plugins() {
         mysql-event-listener
         okta-authenticator
         opensearch
+        oracle
         password-authenticators
         pinot
         postgresql


### PR DESCRIPTION
- Redid the repo `install.sh` script 
- Fixed an issue where the cluster distro wasn't passed in properly
- Fixed an issue where the Starburst license file didn't mount due to unset environment variables
- Bumped image Java version to `22.0.2` to fix a JVM error (listed below)

```
Trino requires -XX:+UnlockDiagnosticVMOptions -XX:G1NumCollectionsKeepPinned=10000000 on Java versions lower than 22.0.2 due to JDK-8329528
```